### PR TITLE
Implementing more CIndexMap features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ version = "0.1.0"
 edition = "2024"
 
 exclude = [
-    "src/tests.rs"
+    "src/tests.rs",
+    "tests"
 ]
 
 [dependencies]

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -228,7 +228,7 @@ impl<K, V> CIndexMap<K, V> {
     }
 }
 
-impl<K: PartialEq + Debug, V> CIndexMap<K, V> {
+impl<K: PartialEq, V> CIndexMap<K, V> {
     /// Gets the value associated with the specified key.
     ///
     /// Multiple implementations exist for `get`:

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,24 @@
+use std::ptr;
+
 /// Returns a `usize` corresponding to the size of a struct time the amount of space for those
 /// structs to be allocated.
 ///
 /// This is useful for when we want to get an accurate memory size to allocate for a map.
 pub(in crate) fn new_capacity_of<T>(size: usize) -> usize {
     size_of::<T>() * size
+}
+
+/// Compares the memory in two pointers.
+///
+/// The index at which the two pointers' underlying data no longer match is returned. This will
+/// return `None` if the two structures are identical.
+pub(in crate) unsafe fn mem_cmp(left: *const u8, right: *const u8, size: usize) -> Option<usize> {
+    // Compare each pointer byte-by-byte.
+    for i in 0..size {
+        if ptr::read(left.add(i)) != ptr::read(right.add(i)) {
+            return Some(i);
+        }
+    }
+
+    None
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,22 @@
+use x_map::maps::CIndexMap;
+
+#[test]
+pub fn test_integration() {
+    let string_one = String::from("foo");
+    let string_two = String::from("bar");
+
+    let mut map = CIndexMap::new();
+    map.insert(string_one.to_string(), string_two.to_string()).unwrap();
+
+    dbg!(map.get(string_one.to_string()));
+    dbg!(map.get_no_peq(string_one.to_string()));
+}
+
+#[test]
+pub fn test_integration_2() {
+    let mut map = CIndexMap::new();
+    map.insert("foo", "bar").unwrap();
+
+    dbg!(map.get("foo").unwrap());
+    dbg!(map.get_no_peq("foo").unwrap());
+}


### PR DESCRIPTION
New features include `get` and `get_no_peq`.
# `get`
Gets a value using `PartialEq` for key comparison.

# `get_no_peq`
In lower-level contexts, where `PartialEq` cannot (for some reason) be implemented, `get_no_peq` may be utilized.